### PR TITLE
add hooks options to custom pages

### DIFF
--- a/.changeset/forty-cycles-sing.md
+++ b/.changeset/forty-cycles-sing.md
@@ -1,0 +1,5 @@
+---
+'@k6js/ks-next': minor
+---
+
+Added various UI hooks, see code for how to use them.

--- a/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
+++ b/packages/keystone/src/___internal-do-not-use-will-break-in-patch/admin-ui/pages/ItemPage/index.tsx
@@ -14,6 +14,7 @@ import {
   useMemo,
   useRef,
   useState,
+  FunctionComponent,
 } from 'react';
 
 import { Button } from '@keystone-ui/button';
@@ -45,8 +46,15 @@ import { GraphQLErrorNotice } from '../../../../admin-ui/components/GraphQLError
 import { CreateItemDrawer } from '../../../../admin-ui/components/CreateItemDrawer';
 import { Container } from '../../../../admin-ui/components/Container';
 
+export type ItemPageHooksProps = Partial<{
+  ItemPageHeader: FunctionComponent<{ listKey: string; item: ItemData }>;
+  ItemPageSidebar: FunctionComponent<{ listKey: string; item: ItemData }>;
+  ItemPageActions: FunctionComponent<{ listKey: string; item: ItemData }>;
+}>;
+
 type ItemPageProps = {
   listKey: string;
+  hooks?: ItemPageHooksProps;
 };
 
 function useEventCallback<Func extends (...args: any) => any>(callback: Func): Func {
@@ -268,7 +276,7 @@ function DeleteButton({
 
 export const getItemPage = (props: ItemPageProps) => () => <ItemPage {...props} />;
 
-const ItemPage = ({ listKey }: ItemPageProps) => {
+const ItemPage = ({ listKey, hooks = {} }: ItemPageProps) => {
   const router = useRouter();
   const { id } = router.query;
   const list = useList(listKey);
@@ -394,6 +402,7 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
                 ? 'Loading...'
                 : (data && data.item && (data.item[list.labelField] || data.item.id)) || id}
             </Heading>
+            {hooks.ItemPageHeader && <hooks.ItemPageHeader listKey={listKey} item={data?.item} />}
           </div>
           {!hideCreate && <CreateButton listKey={listKey} id={data.item.id} />}
         </Container>
@@ -449,6 +458,9 @@ const ItemPage = ({ listKey }: ItemPageProps) => {
                   )}
                 </Tooltip>
               </div>
+              {hooks.ItemPageSidebar && (
+                <hooks.ItemPageSidebar listKey={listKey} item={data?.item} />
+              )}
             </StickySidebar>
           </ColumnLayout>
         </Fragment>


### PR DESCRIPTION
it needs some setting up

for list pages

```tsx
export type ListPageHooksProp = Partial<{
  ListPageHeader: FunctionComponent<{ listKey: string }>;
  ListPrimaryActions: FunctionComponent<{
    listKey: string;
    refetch: () => void;
  }>;
  ListSelectionActions: FunctionComponent<{
    list: ListMeta;
    selectedItems: ReadonlySet<string>;
    refetch: () => void;
  }>;
}>;
```
use in custom list page like this

```tsx
export default getListPage({ listKey: 'Post', hooks });

```

for  item pages

```tsx
export type ItemPageHooksProps = Partial<{
  ItemPageHeader: FunctionComponent<{ listKey: string; item: ItemData }>;
  ItemPageSidebar: FunctionComponent<{ listKey: string; item: ItemData }>;
//   ItemPageActions: FunctionComponent<{ listKey: string; item: ItemData }>; // unused
}>;
```
defines hooks and use it like this in custom pages
```tsx
export default getItemPage({ listKey: 'Post', hooks });
```